### PR TITLE
clear booted models after configuring datastore

### DIFF
--- a/src/Concerns/HasDatastoreDriver.php
+++ b/src/Concerns/HasDatastoreDriver.php
@@ -45,6 +45,8 @@ trait HasDatastoreDriver
     {
         $this->database()->configure();
 
+        parent::clearBootedModels();
+
         return $this;
     }
 


### PR DESCRIPTION
So that models with static connections will get rebooted